### PR TITLE
chore: replace dorny/test-reporter with mikepenz/action-junit-report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,11 @@ jobs:
     - name: Run tests
       run: uv run pytest --junitxml=tests.xml
     - name: Test Report
-      uses: dorny/test-reporter@v2
+      uses: mikepenz/action-junit-report@v6
       if: success() || failure()
       with:
-        name: Test Results (Python version ${{ matrix.python-version }})
-        path: tests.xml
-        reporter: java-junit
+        check_name: Test Results (Python version ${{ matrix.python-version }})
+        report_paths: tests.xml
 
   coverage:
     strategy:


### PR DESCRIPTION
dorny/test-reporter is still on Node.js 20; mikepenz/action-junit-report@v6 uses Node.js 24 natively and supports pytest's JUnit XML output.